### PR TITLE
Usage shows total number of downloads, simulations and visualizations

### DIFF
--- a/api/src/usage/router.py
+++ b/api/src/usage/router.py
@@ -83,3 +83,24 @@ async def get_summarized_simulations() -> dict:
         'detail': 'Data retrieved successfully.' if summarized_data else 'No data retrieved.',
         'result': summarized_data
     }
+
+@router.get('/public/totals/', response_model=ApiResponse)
+async def get_totals() -> dict:
+    """
+    Get the total counts for downloads, visualizations, and simulations.
+    """
+    downloads_count = downloads_collection.count_documents({})
+    visualizations_count = visualizations_collection.count_documents({})
+    simulations_count = simulations_collection.count_documents({})
+
+    totals = {
+        "downloads": downloads_count,
+        "visualizations": visualizations_count,
+        "simulations": simulations_count
+    }
+
+    return {
+        'detail': 'Data retrieved successfully.',
+        'result': totals
+    }
+

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -46,7 +46,7 @@ export function Navbar() {
                 </Group>
                 <Group gap={5} visibleFrom="xs">
 
-                    <Tooltip label="Usage report" position="bottom">
+                    <Tooltip label="Usage Report" position="bottom">
                         <ActionIcon variant="default" size='lg' onClick={() => { openStatsModal(); }}><IconReport stroke={1.5} size={20} /></ActionIcon>
                     </Tooltip>
 

--- a/ui/src/components/UsageStatsModal.tsx
+++ b/ui/src/components/UsageStatsModal.tsx
@@ -1,19 +1,64 @@
+import React, { useEffect, useState } from 'react';
 import { Modal } from '@mantine/core';
 
+type Totals = {
+  downloads: number;
+  visualizations: number;
+  simulations: number;
+};
+
 export function UsageStatsModal({
-    opened,
-    onClose
-}: {
-    opened: boolean;
-    onClose: () => void;
+                                  opened,
+                                  onClose,
+                                }: {
+  opened: boolean;
+  onClose: () => void;
 }) {
-    return (
-        <Modal opened={opened} onClose={onClose} title="Usage report">
-            {/* For now, just some placeholder text */}
-            <p>Usage stats content goes here...</p>
-            <p>How many download events?</p>
-            <p>How many simulation events?</p>
-            <p>Number of simulations?</p>
-        </Modal>
-    );
+  const [totals, setTotals] = useState<Totals | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (opened) {
+      setLoading(true);
+      fetch('http://localhost:8081/usage/public/totals/')
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to retrieve totals');
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (data && data.result) {
+            setTotals(data.result);
+          } else {
+            setError('Invalid data received');
+          }
+        })
+        .catch((err) => {
+          setError(err.message);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+  }, [opened]);
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Usage Report">
+      {loading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p>Error: {error}</p>
+      ) : totals ? (
+        <>
+          <p>Total downloads: {totals.downloads}</p>
+          <p>Total visualizations: {totals.visualizations}</p>
+          <p>Total simulations: {totals.simulations}</p>
+        </>
+      ) : (
+        <p>No data available</p>
+      )}
+    </Modal>
+  );
 }


### PR DESCRIPTION
Added a new endpoint for public/totals (localhost/usage/public/totals) which shows the combined count for respective collections. Modified the UsageStatsModal.tsx for it to fetch data from the api to show the user these numbers.